### PR TITLE
feat: support data urls in file dereferencing

### DIFF
--- a/src/lib/storage/dereferenceFilePaths.test.ts
+++ b/src/lib/storage/dereferenceFilePaths.test.ts
@@ -92,6 +92,22 @@ describe('dereferenceFilePaths', () => {
         `);
   });
 
+  test('loads data urls', async () => {
+    const storage = new InMemoryStorage();
+    const input = {
+      a: 'data:text/plain;base64,aGVsbG8gd29ybGQh',
+    };
+    const output = await dereferenceFilePaths(input, { storage });
+    expect(output).toMatchInlineSnapshot(`
+      {
+        "changed": true,
+        "result": {
+          "a": "hello world!",
+        },
+      }
+    `);
+  });
+
   test('allows referenced yaml to reference additional files', async () => {
     const storage = new InMemoryStorage();
     await storage.writeFile('file:///a.yaml', 'c: 3\nd: file:///b.txt');

--- a/src/lib/storage/dereferenceFilePaths.ts
+++ b/src/lib/storage/dereferenceFilePaths.ts
@@ -80,6 +80,10 @@ export async function dereferenceFilePathsImpl(
       const file = res;
       return handleFile(fileUri, file, options, state);
     }
+    if (val.startsWith('data:')) {
+      const blob = await fetch(val).then((r) => r.blob());
+      return handleBlob(blob, options, state);
+    }
     return val;
   }
   if (Array.isArray(val)) {


### PR DESCRIPTION
## Summary
- handle `data:` URLs in dereferenceFilePaths to treat embedded base64 data as files
- test loading data URLs during file path dereferencing

## Testing
- `CI=1 npm run test` *(fails: Process from config.webServer exited early)*
- `CI=1 npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68c7ac715934832aa8d2158d10b4ec41