### PR TITLE
feat: allow json schema for chrome provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "npm run test:integration && npm run test:unit",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --check . && eslint . && tsc --noEmit -p tsconfig.json",
+    "lint": "svelte-kit sync && prettier --check . && eslint . && tsc --noEmit -p tsconfig.json",
     "format": "prettier --write .",
     "test:integration": "playwright test",
     "test:unit": "vitest"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "npm run test:integration && npm run test:unit",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "svelte-kit sync && prettier --check . && eslint . && tsc --noEmit -p tsconfig.json",
+    "lint": "prettier --check . && eslint . && tsc --noEmit -p tsconfig.json",
     "format": "prettier --write .",
     "test:integration": "playwright test",
     "test:unit": "vitest"

--- a/src/lib/providers/ProviderManager.ts
+++ b/src/lib/providers/ProviderManager.ts
@@ -53,7 +53,7 @@ export class ProviderManager {
     } else if (providerId === 'echo') {
       return new EchoProvider(modelName);
     } else if (providerId === 'chrome' && modelName === 'ai') {
-      return new ChromeProvider();
+      return new ChromeProvider(config);
     } else if (providerId === 'web-llm') {
       return new WebLlm(modelName);
     } else if (providerId === 'ollama') {

--- a/src/lib/providers/chrome.test.ts
+++ b/src/lib/providers/chrome.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect, vi } from 'vitest';
+import { ChromeProvider } from './chrome';
+import type { ConversationPrompt, RunContext } from '$lib/types';
+
+describe('ChromeProvider', () => {
+  test('passes responseConstraint option to promptStreaming', async () => {
+    const schema = { type: 'object', properties: { rating: { type: 'number' } }, required: ['rating'] };
+    const provider = new ChromeProvider({ responseConstraint: schema });
+
+    const promptOptions: unknown[] = [];
+    const mockModel = {
+      promptStreaming: vi.fn(async function* (_messages: unknown, options: unknown) {
+        promptOptions.push(options);
+        yield 'hi';
+      }),
+    };
+
+    const createMock = vi.fn(async (options: any) => {
+      if (options.monitor) {
+        options.monitor({ addEventListener: () => {} });
+      }
+      return mockModel;
+    });
+    const availabilityMock = vi.fn(async () => 'available');
+
+    const globalObj = globalThis as any;
+    const originalLanguageModel = globalObj.LanguageModel;
+    globalObj.LanguageModel = {
+      availability: availabilityMock,
+      create: createMock,
+    };
+
+    try {
+      const conversation: ConversationPrompt = [
+        { role: 'user', content: [{ text: 'Hello' }] },
+      ];
+      const context: RunContext = { abortSignal: new AbortController().signal } as RunContext;
+      const { runModel } = await provider.run(conversation, context);
+      for await (const _ of runModel()) {
+        // consume generator
+      }
+    } finally {
+      if (originalLanguageModel === undefined) {
+        delete globalObj.LanguageModel;
+      } else {
+        globalObj.LanguageModel = originalLanguageModel;
+      }
+    }
+
+    expect(availabilityMock).toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalled();
+    expect(mockModel.promptStreaming).toHaveBeenCalled();
+    const options = promptOptions[0] as Record<string, unknown>;
+    expect(options.responseConstraint).toBe(schema);
+  });
+});

--- a/src/lib/providers/chrome.test.ts
+++ b/src/lib/providers/chrome.test.ts
@@ -21,7 +21,10 @@ describe('ChromeProvider', () => {
       properties: { rating: { type: 'number' } },
       required: ['rating'],
     };
-    const provider = new ChromeProvider({ responseConstraint: schema });
+    const provider = new ChromeProvider({
+      responseConstraint: schema,
+      omitResponseConstraintInput: true,
+    });
 
     const promptOptions: (LanguageModelPromptOptions | undefined)[] = [];
     const promptStreaming = vi.fn<MockLanguageModel['promptStreaming']>((_messages, options) => {
@@ -82,5 +85,8 @@ describe('ChromeProvider', () => {
     expect(promptOptions).toHaveLength(1);
     const [options] = promptOptions;
     expect(options?.responseConstraint).toStrictEqual(schema);
+    const omitResponseConstraintInput = (options as Record<string, unknown> | undefined)
+      ?.omitResponseConstraintInput;
+    expect(omitResponseConstraintInput).toBe(true);
   });
 });

--- a/src/lib/providers/chrome.test.ts
+++ b/src/lib/providers/chrome.test.ts
@@ -2,28 +2,58 @@ import { describe, test, expect, vi } from 'vitest';
 import { ChromeProvider } from './chrome';
 import type { ConversationPrompt, RunContext } from '$lib/types';
 
+interface MockLanguageModel {
+  promptStreaming: (
+    messages: unknown,
+    options?: LanguageModelPromptOptions,
+  ) => ReadableStream<string>;
+}
+
+interface MockLanguageModelConstructor {
+  availability: (options?: LanguageModelCreateCoreOptions) => Promise<Availability>;
+  create: (options?: LanguageModelCreateOptions) => Promise<MockLanguageModel>;
+}
+
 describe('ChromeProvider', () => {
   test('passes responseConstraint option to promptStreaming', async () => {
-    const schema = { type: 'object', properties: { rating: { type: 'number' } }, required: ['rating'] };
+    const schema: Record<string, unknown> = {
+      type: 'object',
+      properties: { rating: { type: 'number' } },
+      required: ['rating'],
+    };
     const provider = new ChromeProvider({ responseConstraint: schema });
 
-    const promptOptions: unknown[] = [];
-    const mockModel = {
-      promptStreaming: vi.fn(async function* (_messages: unknown, options: unknown) {
-        promptOptions.push(options);
-        yield 'hi';
-      }),
+    const promptOptions: (LanguageModelPromptOptions | undefined)[] = [];
+    const promptStreaming = vi.fn<MockLanguageModel['promptStreaming']>((_messages, options) => {
+      promptOptions.push(options);
+      return new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue('hi');
+          controller.close();
+        },
+      });
+    });
+    const mockModel: MockLanguageModel = {
+      promptStreaming,
     };
 
-    const createMock = vi.fn(async (options: any) => {
-      if (options.monitor) {
-        options.monitor({ addEventListener: () => {} });
+    const createMockImplementation: MockLanguageModelConstructor['create'] = (options) => {
+      if (options?.monitor) {
+        const monitor = new EventTarget() as CreateMonitor;
+        monitor.ondownloadprogress = null;
+        options.monitor(monitor);
       }
-      return mockModel;
-    });
-    const availabilityMock = vi.fn(async () => 'available');
+      return Promise.resolve(mockModel);
+    };
+    const createMock = vi.fn(createMockImplementation);
 
-    const globalObj = globalThis as any;
+    const availabilityMockImplementation: MockLanguageModelConstructor['availability'] = () =>
+      Promise.resolve('available');
+    const availabilityMock = vi.fn(availabilityMockImplementation);
+
+    const globalObj = globalThis as typeof globalThis & {
+      LanguageModel?: MockLanguageModelConstructor;
+    };
     const originalLanguageModel = globalObj.LanguageModel;
     globalObj.LanguageModel = {
       availability: availabilityMock,
@@ -31,12 +61,11 @@ describe('ChromeProvider', () => {
     };
 
     try {
-      const conversation: ConversationPrompt = [
-        { role: 'user', content: [{ text: 'Hello' }] },
-      ];
-      const context: RunContext = { abortSignal: new AbortController().signal } as RunContext;
-      const { runModel } = await provider.run(conversation, context);
-      for await (const _ of runModel()) {
+      const conversation: ConversationPrompt = [{ role: 'user', content: [{ text: 'Hello' }] }];
+      const context: RunContext = { abortSignal: new AbortController().signal };
+      const result = await provider.run(conversation, context);
+      const generator = result.runModel();
+      for await (const _chunk of generator) {
         // consume generator
       }
     } finally {
@@ -50,7 +79,8 @@ describe('ChromeProvider', () => {
     expect(availabilityMock).toHaveBeenCalled();
     expect(createMock).toHaveBeenCalled();
     expect(mockModel.promptStreaming).toHaveBeenCalled();
-    const options = promptOptions[0] as Record<string, unknown>;
-    expect(options.responseConstraint).toBe(schema);
+    expect(promptOptions).toHaveLength(1);
+    const [options] = promptOptions;
+    expect(options?.responseConstraint).toStrictEqual(schema);
   });
 });

--- a/src/lib/providers/chrome.ts
+++ b/src/lib/providers/chrome.ts
@@ -96,11 +96,11 @@ interface SessionState {
 
 const configSchema = normalizedProviderConfigSchema
   .extend({
-    responseConstraint: z.unknown().optional(),
+    responseConstraint: z.record(z.unknown()).optional(),
   })
   .passthrough();
 export type ChromeConfig = NormalizedProviderConfig & {
-  responseConstraint?: unknown;
+  responseConstraint?: Record<string, unknown>;
 };
 
 export class ChromeProvider implements ModelProvider {
@@ -118,7 +118,7 @@ export class ChromeProvider implements ModelProvider {
     'audio/flac',
   ];
 
-  private responseConstraint?: unknown;
+  private responseConstraint?: Record<string, unknown>;
 
   constructor(config: ChromeConfig = {}) {
     const { mimeTypes, responseConstraint } = configSchema.parse(config);
@@ -192,7 +192,7 @@ export class ChromeProvider implements ModelProvider {
         yield { type: 'replace', output: '' } as ModelUpdate;
 
         let reply = '';
-        const options: { signal: AbortSignal; responseConstraint?: unknown } = {
+        const options: LanguageModelPromptOptions = {
           signal: context.abortSignal,
         };
         if (responseConstraint !== undefined) {

--- a/src/lib/providers/openai.test.ts
+++ b/src/lib/providers/openai.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { describe, expect, test } from 'vitest';
 import { OpenaiProvider } from './openai';
 

--- a/src/routes/documentation/+page.md
+++ b/src/routes/documentation/+page.md
@@ -64,7 +64,7 @@ Currently supported model providers:
 - [x] Gemini -- prefix with `gemini:`, e.g. `gemini:gemini-2.5-pro`. Requires `GEMINI_API_KEY` in your environment.
 - [x] Gemini Live -- prefix with `gemini-live:`, e.g. `gemini-live:gemini-2.5-flash-preview-native-audio-dialog`. Requires `GEMINI_API_KEY` in your environment.
 - [x] OpenAI -- prefix with `openai:`, e.g. `openai:gpt-4o`. Requires `OPENAI_API_KEY` in your environment.
-- [x] [Chrome](https://goo.gle/chrome-ai-dev-preview) -- use `chrome:ai`.
+- [x] [Chrome](https://goo.gle/chrome-ai-dev-preview) -- use `chrome:ai`. Supports `config.responseConstraint` to constrain responses with a JSON Schema.
 - [x] Ollama -- prefix with `ollama:`, e.g. `ollama:gemma-2:2b`. Requires `OLLAMA_ENDPOINT` (e.g. `http://localhost:11434`) in your environment, or the `apiBaseUrl` config option.
 - [x] [WebLLM](https://github.com/mlc-ai/web-llm) -- prefix with `web-llm:`, e.g. `web-llm:gemma-2-2b-it-q4f32_1-MLC`. See [here](https://github.com/mlc-ai/web-llm/blob/main/src/config.ts#L309) for a list of supported model IDs. Requires [WebGPU](https://caniuse.com/webgpu).
 - [x] Anthropic -- prefix with `anthropic:`, e.g. `anthropic:claude-3-5-sonnet-latest`. Requires `ANTHROPIC_API_KEY` in your environment.
@@ -85,6 +85,13 @@ providers:
     config:
       generationConfig:
         responseMimeType: application/json
+  - id: chrome:ai
+    config:
+      responseConstraint:
+        type: object
+        properties:
+          rating: { type: number }
+        required: ['rating']
 ```
 
 You may also specify a `mimeTypes: string[]` in the `config` to override the model's default supported mime-types.

--- a/src/routes/documentation/+page.md
+++ b/src/routes/documentation/+page.md
@@ -64,7 +64,7 @@ Currently supported model providers:
 - [x] Gemini -- prefix with `gemini:`, e.g. `gemini:gemini-2.5-pro`. Requires `GEMINI_API_KEY` in your environment.
 - [x] Gemini Live -- prefix with `gemini-live:`, e.g. `gemini-live:gemini-2.5-flash-preview-native-audio-dialog`. Requires `GEMINI_API_KEY` in your environment.
 - [x] OpenAI -- prefix with `openai:`, e.g. `openai:gpt-4o`. Requires `OPENAI_API_KEY` in your environment.
-- [x] [Chrome](https://goo.gle/chrome-ai-dev-preview) -- use `chrome:ai`. Supports `config.responseConstraint` to constrain responses with a JSON Schema.
+- [x] [Chrome](https://goo.gle/chrome-ai-dev-preview) -- use `chrome:ai`. Supports `config.responseConstraint` to constrain responses with a JSON Schema and `config.omitResponseConstraintInput` to skip including the constraint in prompt input.
 - [x] Ollama -- prefix with `ollama:`, e.g. `ollama:gemma-2:2b`. Requires `OLLAMA_ENDPOINT` (e.g. `http://localhost:11434`) in your environment, or the `apiBaseUrl` config option.
 - [x] [WebLLM](https://github.com/mlc-ai/web-llm) -- prefix with `web-llm:`, e.g. `web-llm:gemma-2-2b-it-q4f32_1-MLC`. See [here](https://github.com/mlc-ai/web-llm/blob/main/src/config.ts#L309) for a list of supported model IDs. Requires [WebGPU](https://caniuse.com/webgpu).
 - [x] Anthropic -- prefix with `anthropic:`, e.g. `anthropic:claude-3-5-sonnet-latest`. Requires `ANTHROPIC_API_KEY` in your environment.
@@ -92,6 +92,7 @@ providers:
         properties:
           rating: { type: number }
         required: ['rating']
+      omitResponseConstraintInput: true
 ```
 
 You may also specify a `mimeTypes: string[]` in the `config` to override the model's default supported mime-types.


### PR DESCRIPTION
## Summary
- allow responseConstraint config for chrome:ai provider and forward to LanguageModel
- pass provider config through ProviderManager
- document responseConstraint usage and add unit test

## Testing
- `CI=1 npm run test` (fails: Timed out waiting 60000ms from config.webServer.)
- `CI=1 npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68c7b1e95894832a8d73212a1566f873